### PR TITLE
Remove extraneous CC-BY-4.0 identifier

### DIFF
--- a/src/main/rexx/com/zos/rexx/BCPiiTest.rexx
+++ b/src/main/rexx/com/zos/rexx/BCPiiTest.rexx
@@ -8,8 +8,7 @@
     myConnectType = 6 = HWI_LOAD_ACTPROF                                    
     myConnectType = 7 = HWI_IMAGE_GROUP      
     
-    SPDX-License-Identifier: Apache-2.0 
-    SPDX-License-Identifier: CC-BY-4.0
+    SPDX-License-Identifier: Apache-2.0
 */                                                                          
 myConnectType = 1                                                           
 myConnectTypeValue  = 'IBM390PS.P00XXXXX' /* 17-char CPC name */            


### PR DESCRIPTION
Signed-off-by: Steve Winslow <steve@swinslow.net>